### PR TITLE
simple-http-server review fix

### DIFF
--- a/simple-http-server/src/main/java/ServerSocketExample.java
+++ b/simple-http-server/src/main/java/ServerSocketExample.java
@@ -2,10 +2,11 @@
 
 import socket.CustomSocket;
 
-import java.io.*;
+import java.io.IOException;
 import java.net.ServerSocket;
 
-import static util.Constant.*;
+import static util.Constant.DEFAULT_PORT;
+import static util.Constant.PATH_STATIC_FOLDER;
 
 public class ServerSocketExample {
 
@@ -13,8 +14,14 @@ public class ServerSocketExample {
         try (ServerSocket serverSocket = new ServerSocket(DEFAULT_PORT)) {
             System.out.printf("Server started at http://localhost:%s\n", DEFAULT_PORT);
 
-            CustomSocket customSocket = new CustomSocket();
-            customSocket.getConnection(serverSocket);
+            CustomSocket customSocket = new CustomSocket(getPathOrDefault(args));
+            customSocket.establishConnection(serverSocket);
         }
+    }
+
+    private static String getPathOrDefault(String[] args) {
+        return args == null || args.length == 0 || args[0] == null
+            ? PATH_STATIC_FOLDER
+            : args[0];
     }
 }

--- a/simple-http-server/src/main/java/dispatcher/BinaryResponser.java
+++ b/simple-http-server/src/main/java/dispatcher/BinaryResponser.java
@@ -5,11 +5,12 @@ import java.io.IOException;
 import java.nio.channels.UnsupportedAddressTypeException;
 import java.nio.charset.StandardCharsets;
 
+import static util.Constant.HTTP_404_ERROR_RESPONSE;
 import static util.FileUtils.getFileContentBinary;
 import static util.FileUtils.getFileContentType;
 
 public class BinaryResponser implements Responser<byte[]>{
-    private static final byte[] ERROR_RESPONSE_404 = "HTTP1.1/ 404 Not found".getBytes();
+    private static final byte[] ERROR_RESPONSE_404 = HTTP_404_ERROR_RESPONSE.getBytes();
 
     public byte[] getResponse(File file) {
         try {
@@ -25,17 +26,18 @@ public class BinaryResponser implements Responser<byte[]>{
         byte[] fileContent = getFileContentBinary(file);
         String contentType = getFileContentType(file);
 
-        String headers = """
+        String responseText = """
         HTTP/1.1 200 OK
         Content-Type: %s
         Content-Length: %d
         
         """.formatted(contentType, fileContent.length);
-        byte[] headersBytes = headers.getBytes(StandardCharsets.UTF_8);
 
-        byte[] response = new byte[headersBytes.length + fileContent.length];
-        System.arraycopy(headersBytes, 0, response, 0, headersBytes.length);
-        System.arraycopy(fileContent, 0, response, headersBytes.length, fileContent.length);
+        byte[] responseTextBytes = responseText.getBytes(StandardCharsets.UTF_8);
+        byte[] response = new byte[responseTextBytes.length + fileContent.length];
+
+        System.arraycopy(responseTextBytes, 0, response, 0, responseTextBytes.length);
+        System.arraycopy(fileContent, 0, response, responseTextBytes.length, fileContent.length);
 
         return response;
     }

--- a/simple-http-server/src/main/java/dispatcher/BinaryResponser.java
+++ b/simple-http-server/src/main/java/dispatcher/BinaryResponser.java
@@ -1,43 +1,21 @@
 package dispatcher;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.channels.UnsupportedAddressTypeException;
 import java.nio.charset.StandardCharsets;
 
-import static util.Constant.HTTP_404_ERROR_RESPONSE;
-import static util.FileUtils.getFileContentBinary;
-import static util.FileUtils.getFileContentType;
-
-public class BinaryResponser implements Responser<byte[]>{
-    private static final byte[] ERROR_RESPONSE_404 = HTTP_404_ERROR_RESPONSE.getBytes();
-
-    public byte[] getResponse(File file) {
-        try {
-            return file.exists()
-                    ? getSuccessResponse(file)
-                    : ERROR_RESPONSE_404;
-        } catch (UnsupportedAddressTypeException | IOException e) {
-            return ERROR_RESPONSE_404;
-        }
-    }
-
-    private byte[] getSuccessResponse(File file) throws IOException {
-        byte[] fileContent = getFileContentBinary(file);
-        String contentType = getFileContentType(file);
-
+public class BinaryResponser implements Responser<byte[]> {
+    public byte[] getResponse(byte[] content, String contentType) {
         String responseText = """
-        HTTP/1.1 200 OK
-        Content-Type: %s
-        Content-Length: %d
-        
-        """.formatted(contentType, fileContent.length);
+                HTTP/1.1 200 OK
+                Content-Type: %s
+                Content-Length: %d
+                
+                """.formatted(contentType, content.length);
 
         byte[] responseTextBytes = responseText.getBytes(StandardCharsets.UTF_8);
-        byte[] response = new byte[responseTextBytes.length + fileContent.length];
+        byte[] response = new byte[responseTextBytes.length + content.length];
 
         System.arraycopy(responseTextBytes, 0, response, 0, responseTextBytes.length);
-        System.arraycopy(fileContent, 0, response, responseTextBytes.length, fileContent.length);
+        System.arraycopy(content, 0, response, responseTextBytes.length, content.length);
 
         return response;
     }

--- a/simple-http-server/src/main/java/dispatcher/Responser.java
+++ b/simple-http-server/src/main/java/dispatcher/Responser.java
@@ -1,7 +1,26 @@
 package dispatcher;
 
-import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 public interface Responser<T> {
-    T getResponse(File file);
+    String HTTP_400_ERROR_RESPONSE = "HTTP/1.1 400 Bad Request";
+    String HTTP_404_ERROR_RESPONSE = "HTTP/1.1 404 Not found";
+    String HTTP_500_ERROR_RESPONSE = "HTTP/1.1 500 Internal Server Error";
+
+    Integer BAD_REQUEST_STATUS = 400;
+    Integer NOT_FOUND_STATUS = 404;
+    Integer INTERNAL_SERVER_ERROR_STATUS = 500;
+
+    Map<Integer, String> HTTP_STATUS_TO_ERROR_RESPONSE = new HashMap<>(){{
+        put(BAD_REQUEST_STATUS, HTTP_400_ERROR_RESPONSE);
+        put(NOT_FOUND_STATUS, HTTP_404_ERROR_RESPONSE);
+        put(INTERNAL_SERVER_ERROR_STATUS, HTTP_500_ERROR_RESPONSE);
+    }};
+
+    T getResponse(T content, String contentType);
+
+    static String getErrorResponseByHttpStatus(Integer code) {
+        return HTTP_STATUS_TO_ERROR_RESPONSE.getOrDefault(code, HTTP_404_ERROR_RESPONSE);
+    }
 }

--- a/simple-http-server/src/main/java/dispatcher/TextResponser.java
+++ b/simple-http-server/src/main/java/dispatcher/TextResponser.java
@@ -1,37 +1,14 @@
 package dispatcher;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.channels.UnsupportedAddressTypeException;
-
-import static util.Constant.HTTP_404_ERROR_RESPONSE;
-import static util.FileUtils.getFileContentText;
-import static util.FileUtils.getFileContentType;
-
 public class TextResponser implements Responser<String> {
 
-    public String getResponse(File file) {
-        try {
-            return file.exists()
-                    ? getSuccessResponse(file)
-                    : HTTP_404_ERROR_RESPONSE;
-        } catch (UnsupportedAddressTypeException | IOException e) {
-            return HTTP_404_ERROR_RESPONSE;
-        }
-    }
-
-    private String getSuccessResponse(File file) throws IOException {
-        String contentType = getFileContentType(file);
+    public String getResponse(String content, String contentType) {
         return """
                 HTTP/1.1 200 OK
                 Content-type: %s; charset=UTF-8
                 Content-length: %d
                 
                 %s
-                """.formatted(contentType, file.length(), getFileContentText(file));
-    }
-
-    public String getErrorResponse404() {
-        return HTTP_404_ERROR_RESPONSE;
+                """.formatted(contentType, content.length(), content);
     }
 }

--- a/simple-http-server/src/main/java/dispatcher/TextResponser.java
+++ b/simple-http-server/src/main/java/dispatcher/TextResponser.java
@@ -4,25 +4,26 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.channels.UnsupportedAddressTypeException;
 
-import static util.FileUtils.*;
+import static util.Constant.HTTP_404_ERROR_RESPONSE;
+import static util.FileUtils.getFileContentText;
+import static util.FileUtils.getFileContentType;
 
 public class TextResponser implements Responser<String> {
-    private static final String ERROR_RESPONSE_404 = "HTTP1.1/ 404 Not found";
 
     public String getResponse(File file) {
         try {
             return file.exists()
                     ? getSuccessResponse(file)
-                    : ERROR_RESPONSE_404;
+                    : HTTP_404_ERROR_RESPONSE;
         } catch (UnsupportedAddressTypeException | IOException e) {
-            return ERROR_RESPONSE_404;
+            return HTTP_404_ERROR_RESPONSE;
         }
     }
 
     private String getSuccessResponse(File file) throws IOException {
         String contentType = getFileContentType(file);
         return """
-                HTTP1.1/ 200 OK
+                HTTP/1.1 200 OK
                 Content-type: %s; charset=UTF-8
                 Content-length: %d
                 
@@ -31,6 +32,6 @@ public class TextResponser implements Responser<String> {
     }
 
     public String getErrorResponse404() {
-        return ERROR_RESPONSE_404;
+        return HTTP_404_ERROR_RESPONSE;
     }
 }

--- a/simple-http-server/src/main/java/socket/CustomSocket.java
+++ b/simple-http-server/src/main/java/socket/CustomSocket.java
@@ -1,6 +1,7 @@
 package socket;
 
 import dispatcher.BinaryResponser;
+import dispatcher.Responser;
 import dispatcher.TextResponser;
 
 import java.io.BufferedReader;
@@ -8,16 +9,14 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.nio.channels.UnsupportedAddressTypeException;
+import java.nio.file.NoSuchFileException;
 
-import static util.Constant.ContentType.BINARY_CONTENT_TYPE_SUPPORTED_SET;
-import static util.Constant.ContentType.NON_BINARY_CONTENT_TYPE_SUPPORTED_SET;
+import static dispatcher.Responser.*;
 import static util.Constant.Symbols.SPACE;
-import static util.FileUtils.getFileContentType;
+import static util.FileUtils.*;
 
 public class CustomSocket {
     private final String pathToResources;
@@ -33,57 +32,53 @@ public class CustomSocket {
     public void establishConnection(ServerSocket serverSocket) throws IOException {
         while (true) {
             try (Socket connection = serverSocket.accept()) {
-                String fileName = getFileNameFromRequest(connection);
-                writeResponse(connection, fileName);
+                try {
+                    File currentFile = getFileFromRequest(connection);
+                    String contentType = getFileContentType(currentFile);
+                    if (isBinaryFileByContentType(contentType)) {
+                        writeResponse(connection, getFileContentBinary(currentFile), contentType);
+                        return;
+                    }
+                    if (isTextFileByContentType(contentType)){
+                        writeResponse(connection, getFileContentText(currentFile), contentType);
+                        return;
+                    }
+                    throw new IllegalArgumentException();
+                } catch (IllegalArgumentException e) {
+                    writeErrorResponse(connection, BAD_REQUEST_STATUS);
+                } catch (NoSuchFileException e) {
+                    writeErrorResponse(connection, NOT_FOUND_STATUS);
+                } catch (RuntimeException e) {
+                    writeErrorResponse(connection, INTERNAL_SERVER_ERROR_STATUS);
+                }
             }
         }
     }
 
-    private String getFileNameFromRequest(Socket connection) throws IOException {
-        var bufferedInputStream = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-        String line = bufferedInputStream.readLine();
-        return line == null || line.isEmpty()
-                ? null
-                : line.split(SPACE)[1];
-    }
-
-    private void writeResponse(Socket connection, String fileFullName) throws IOException {
-        var binaryOutputStream = connection.getOutputStream();
-        var textWriter = new BufferedWriter(new OutputStreamWriter(binaryOutputStream));
-
-        if (fileFullName == null || fileFullName.isEmpty()) {
-            sendResponseAndFlush(textWriter, textResponser.getErrorResponse404());
-            return;
-        }
-
-        File currentFile = new File(pathToResources.concat(fileFullName));
-
-        try {
-            String contentType = getFileContentType(currentFile);
-            if (BINARY_CONTENT_TYPE_SUPPORTED_SET.contains(contentType)) {
-                sendResponseAndFlush(binaryOutputStream, binaryResponser.getResponse(currentFile));
-                return;
-            }
-            if (NON_BINARY_CONTENT_TYPE_SUPPORTED_SET.contains(contentType)) {
-                sendResponseAndFlush(textWriter, textResponser.getResponse(currentFile));
-                return;
-            }
-            sendResponseAndFlush(textWriter, textResponser.getErrorResponse404());
-        } catch (RuntimeException e) {
-            sendResponseAndFlush(textWriter, textResponser.getErrorResponse404());
-        }
-
-    }
-
-    private void sendResponseAndFlush(BufferedWriter writer, String content) throws IOException {
-        writer.write(content);
+    private static void writeErrorResponse(Socket connection, Integer status) throws IOException {
+        var writer = new BufferedWriter(new OutputStreamWriter(connection.getOutputStream()));
+        writer.write(Responser.getErrorResponseByHttpStatus(status));
         writer.flush();
     }
 
-    private void sendResponseAndFlush(OutputStream outputStream, byte[] content) throws IOException {
-        outputStream.write(content);
-        outputStream.flush();
+    private File getFileFromRequest(Socket connection) throws IOException {
+        var bufferedInputStream = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        String line = bufferedInputStream.readLine();
+        if (line == null || !line.contains(SPACE)) {
+            throw new IllegalArgumentException();
+        }
+        return new File(pathToResources.concat(line.split(SPACE)[1]));
     }
 
+    private void writeResponse(Socket connection, String content, String contentType) throws IOException {
+        var writer = new BufferedWriter(new OutputStreamWriter(connection.getOutputStream()));
+        writer.write(textResponser.getResponse(content, contentType));
+        writer.flush();
+    }
 
+    private void writeResponse(Socket connection, byte[] content, String contentType) throws IOException {
+        var binaryOutputStream = connection.getOutputStream();
+        binaryOutputStream.write(binaryResponser.getResponse(content, contentType));
+        binaryOutputStream.flush();
+    }
 }

--- a/simple-http-server/src/main/java/socket/CustomSocket.java
+++ b/simple-http-server/src/main/java/socket/CustomSocket.java
@@ -3,43 +3,34 @@ package socket;
 import dispatcher.BinaryResponser;
 import dispatcher.TextResponser;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.channels.UnsupportedAddressTypeException;
-import java.util.Objects;
-import java.util.Scanner;
 
-import static util.Constant.ContentType.BINARY_CONTENT_TYPE_SUPPORTED_LIST;
-import static util.Constant.ContentType.NON_BINARY_CONTENT_TYPE_SUPPORTED_LIST;
-import static util.Constant.PATH_STATIC_FOLDER;
-import static util.Constant.Symbols.SHORT_YES;
+import static util.Constant.ContentType.BINARY_CONTENT_TYPE_SUPPORTED_SET;
+import static util.Constant.ContentType.NON_BINARY_CONTENT_TYPE_SUPPORTED_SET;
 import static util.Constant.Symbols.SPACE;
 import static util.FileUtils.getFileContentType;
 
 public class CustomSocket {
-    private final String PATH_TO_RESOURCES;
+    private final String pathToResources;
     private final BinaryResponser binaryResponser;
     private final TextResponser textResponser;
 
-    public CustomSocket() {
+    public CustomSocket(String path) {
         this.binaryResponser = new BinaryResponser();
         this.textResponser = new TextResponser();
-        try (Scanner scanner = new Scanner(System.in)) {
-            System.out.println("Do you want to use default path to resources? [Y/N]");
-            String inputData = scanner.nextLine();
-            if (SHORT_YES.equals(inputData)) {
-                this.PATH_TO_RESOURCES = PATH_STATIC_FOLDER;
-                System.out.println("The default path to resources is selected");
-                return;
-            }
-            System.out.println("Input path to resources:"); // D:/PabloPackage/java_project/payment-service/simple-http-server/src/main/resources/static/customPath
-            this.PATH_TO_RESOURCES = scanner.nextLine();
-            System.out.printf("The path to resources: %s\n", this.PATH_TO_RESOURCES);
-        }
+        this.pathToResources = path;
     }
 
-    public void getConnection(ServerSocket serverSocket) throws IOException {
+    public void establishConnection(ServerSocket serverSocket) throws IOException {
         while (true) {
             try (Socket connection = serverSocket.accept()) {
                 String fileName = getFileNameFromRequest(connection);
@@ -50,42 +41,35 @@ public class CustomSocket {
 
     private String getFileNameFromRequest(Socket connection) throws IOException {
         var bufferedInputStream = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-        String line;
-        String fileFullName = null;
-        for (boolean isFirstLine = true;(line = bufferedInputStream.readLine()) != null && !line.isEmpty();) {
-            System.out.println(line);
-            if (isFirstLine) {
-                isFirstLine = false;
-                fileFullName = line.split(SPACE)[1];
-            }
-        }
-        System.out.println();
-        return fileFullName;
+        String line = bufferedInputStream.readLine();
+        return line == null || line.isEmpty()
+                ? null
+                : line.split(SPACE)[1];
     }
 
     private void writeResponse(Socket connection, String fileFullName) throws IOException {
         var binaryOutputStream = connection.getOutputStream();
         var textWriter = new BufferedWriter(new OutputStreamWriter(binaryOutputStream));
 
-        if (Objects.isNull(fileFullName) || fileFullName.isEmpty()) {
+        if (fileFullName == null || fileFullName.isEmpty()) {
             sendResponseAndFlush(textWriter, textResponser.getErrorResponse404());
             return;
         }
 
-        File currentFile = new File(PATH_TO_RESOURCES.concat(fileFullName));
+        File currentFile = new File(pathToResources.concat(fileFullName));
 
         try {
             String contentType = getFileContentType(currentFile);
-            if (BINARY_CONTENT_TYPE_SUPPORTED_LIST.contains(contentType)) {
+            if (BINARY_CONTENT_TYPE_SUPPORTED_SET.contains(contentType)) {
                 sendResponseAndFlush(binaryOutputStream, binaryResponser.getResponse(currentFile));
                 return;
             }
-            if (NON_BINARY_CONTENT_TYPE_SUPPORTED_LIST.contains(contentType)) {
+            if (NON_BINARY_CONTENT_TYPE_SUPPORTED_SET.contains(contentType)) {
                 sendResponseAndFlush(textWriter, textResponser.getResponse(currentFile));
                 return;
             }
             sendResponseAndFlush(textWriter, textResponser.getErrorResponse404());
-        } catch (UnsupportedAddressTypeException e) {
+        } catch (RuntimeException e) {
             sendResponseAndFlush(textWriter, textResponser.getErrorResponse404());
         }
 

--- a/simple-http-server/src/main/java/util/Constant.java
+++ b/simple-http-server/src/main/java/util/Constant.java
@@ -2,18 +2,17 @@ package util;
 
 import java.io.File;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface Constant {
     int DEFAULT_PORT = 8080;
     String PATH_STATIC_FOLDER = new File("").getAbsolutePath().concat("/simple-http-server/src/main/resources/static");
+    String HTTP_404_ERROR_RESPONSE = "HTTP/1.1 404 Not found";
 
     interface Symbols {
         String SPACE = " ";
         String DOT = "\\.";
-        String SHORT_YES = "Y";
-        String SHORT_NO = "N";
     }
 
     interface ContentType {
@@ -24,6 +23,7 @@ public interface Constant {
             put("png", "image/png");
         }};
 
-        List<String> BINARY_CONTENT_TYPE_SUPPORTED_LIST = List.of("image/png");
-        List<String> NON_BINARY_CONTENT_TYPE_SUPPORTED_LIST = List.of("text/html", "text/css", "application/javascript");
-    }}
+        Set<String> BINARY_CONTENT_TYPE_SUPPORTED_SET = Set.of("image/png");
+        Set<String> NON_BINARY_CONTENT_TYPE_SUPPORTED_SET = Set.of("text/html", "text/css", "application/javascript");
+    }
+}

--- a/simple-http-server/src/main/java/util/Constant.java
+++ b/simple-http-server/src/main/java/util/Constant.java
@@ -8,7 +8,6 @@ import java.util.Set;
 public interface Constant {
     int DEFAULT_PORT = 8080;
     String PATH_STATIC_FOLDER = new File("").getAbsolutePath().concat("/simple-http-server/src/main/resources/static");
-    String HTTP_404_ERROR_RESPONSE = "HTTP/1.1 404 Not found";
 
     interface Symbols {
         String SPACE = " ";

--- a/simple-http-server/src/main/java/util/FileUtils.java
+++ b/simple-http-server/src/main/java/util/FileUtils.java
@@ -3,11 +3,12 @@ package util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.channels.UnsupportedAddressTypeException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllBytes;
-import static util.Constant.ContentType.FILE_TYPE_TO_CONTENT_TYPE_MAP;
+import static util.Constant.ContentType.*;
 import static util.Constant.Symbols.DOT;
 
 public class FileUtils {
@@ -20,11 +21,25 @@ public class FileUtils {
     }
 
     public static String getFileContentText(File file) throws IOException {
+        if (!file.exists()) {
+            throw new NoSuchFileException(file.getName());
+        }
         byte[] bytes = readAllBytes(Path.of(file.getPath()));
         return new String(bytes, UTF_8);
     }
 
     public static byte[] getFileContentBinary(File file) throws IOException {
+        if (!file.exists()) {
+            throw new NoSuchFileException(file.getName());
+        }
         return readAllBytes(Path.of(file.getPath()));
+    }
+
+    public static boolean isBinaryFileByContentType(String type) {
+        return BINARY_CONTENT_TYPE_SUPPORTED_SET.contains(type);
+    }
+
+    public static boolean isTextFileByContentType(String type) {
+        return NON_BINARY_CONTENT_TYPE_SUPPORTED_SET.contains(type);
     }
 }

--- a/simple-http-server/src/main/java/util/FileUtils.java
+++ b/simple-http-server/src/main/java/util/FileUtils.java
@@ -7,14 +7,13 @@ import java.nio.file.Path;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllBytes;
-import static java.util.Objects.isNull;
 import static util.Constant.ContentType.FILE_TYPE_TO_CONTENT_TYPE_MAP;
 import static util.Constant.Symbols.DOT;
 
 public class FileUtils {
     public static String getFileContentType(File file) {
         String contentType = FILE_TYPE_TO_CONTENT_TYPE_MAP.get(file.getName().split(DOT)[1]);
-        if (isNull(contentType)) {
+        if (contentType == null) {
             throw new UnsupportedAddressTypeException();
         }
         return contentType;

--- a/simple-http-server/src/main/resources/requests.txt
+++ b/simple-http-server/src/main/resources/requests.txt
@@ -7,4 +7,7 @@ Default path:
         http://localhost:8080/script.js
     error404:
         http://localhost:8080/any.html
+    error400:
         http://localhost:8080/index.htmlll
+    error500
+        http://localhost:8080/index


### PR DESCRIPTION
> 11) byte[] response = new byte[headersBytes.length + fileContent.length];
>         System.arraycopy(headersBytes, 0, response, 0, headersBytes.length);
>         System.arraycopy(fileContent, 0, response, headersBytes.length, fileContent.length);
> 		
> 	Для чего используется копирование байтов в последних двух строках

Для передачи файлов/изображений приходится отказаться от передачи в BufferWriter в пользу передачи байтов напрямую в OutputStream. Для этого нужно объединить два массива byte[] в один:
1. byte[] полученный из start-line и headers и empty-line
2. byte[] полученный из контента файла

_System.arraycopy() -> нативный метод по копированию массива_
Копируем оба массива в итоговый:
Первые responseTextBytes.length элементов копия **byte[] responseTextBytes**
Элементы с responseTextBytes.length по (responseTextBytes.length + fileContent.length) копия **byte[] fileContent**